### PR TITLE
setup: update distros that need internal libint

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -124,8 +124,9 @@ if [[ ${INPUT_DISTRO} = "gentoo:latest"  ]]; then
   cmake_args+=( -DBUILD_CSG_MANUAL=OFF )
 fi
 
-# Gentoo has no libint yet
-if [[ ${INPUT_DISTRO} = "opensuse:latest"  ]]; then
+# Some distros don't have new enough libint yet
+# fedora:latest = F32 only has libint2-2.1.0
+if [[ ${INPUT_DISTRO} = "fedora:latest"  ]]; then
   cmake_args+=( -DBUILD_OWN_LIBINT=ON )
 fi
 


### PR DESCRIPTION
For https://github.com/votca/xtp/pull/559

Make sure I didn't forget a distro, `fedora:latest` ( = `fedora:32` right now) only has libint2-2.1.0.

`ubuntu:18.04` has libint-2.3.0 that should hopefully be ok.